### PR TITLE
Fix issue on CPU in mask_logits_fast. Only pin if cuda device type.

### DIFF
--- a/python/kbnf/engine.py
+++ b/python/kbnf/engine.py
@@ -52,14 +52,14 @@ def _torch_fast_mask_logits(module:types.ModuleType):
                 if length == 0: # Rust FFI requires non-null pointer
                     return tensor
                 disallowed = module.empty((length,), device="cpu",dtype=module.int64)
-                if tensor.device.type == 'cuda':
+                if tensor.is_cuda:
                     disallowed.pin_memory()
                 data_ptr = disallowed.data_ptr()
                 assert data_ptr % 8 == 0, f"The indices data pointer which points to {data_ptr} is not aligned to 8 bytes"
                 engine.write_disallowed_token_ids_to_buffer(data_ptr, length)
                 length = engine.get_number_of_allowed_token_ids()
                 allowed = module.empty((length,), device="cpu",dtype=module.int64)
-                if tensor.device.type == 'cuda':
+                if tensor.is_cuda:
                     allowed.pin_memory()
                 data_ptr = allowed.data_ptr()
                 assert data_ptr % 8 == 0, f"The allowed data pointer which points to {data_ptr} is not aligned to 8 bytes"

--- a/python/kbnf/engine.py
+++ b/python/kbnf/engine.py
@@ -52,13 +52,15 @@ def _torch_fast_mask_logits(module:types.ModuleType):
                 if length == 0: # Rust FFI requires non-null pointer
                     return tensor
                 disallowed = module.empty((length,), device="cpu",dtype=module.int64)
-                disallowed.pin_memory()
+                if tensor.device.type == 'cuda':
+                    disallowed.pin_memory()
                 data_ptr = disallowed.data_ptr()
                 assert data_ptr % 8 == 0, f"The indices data pointer which points to {data_ptr} is not aligned to 8 bytes"
                 engine.write_disallowed_token_ids_to_buffer(data_ptr, length)
                 length = engine.get_number_of_allowed_token_ids()
                 allowed = module.empty((length,), device="cpu",dtype=module.int64)
-                allowed.pin_memory()
+                if tensor.device.type == 'cuda':
+                    allowed.pin_memory()
                 data_ptr = allowed.data_ptr()
                 assert data_ptr % 8 == 0, f"The allowed data pointer which points to {data_ptr} is not aligned to 8 bytes"
                 engine.write_allowed_token_ids_to_buffer(data_ptr, length)


### PR DESCRIPTION
Fix for below error on CPU.

```
NotImplementedError: Could not run 'aten::_pin_memory' with arguments from the 'CUDA' backend. This could be because the operator doesn't exist for this backend, or was omitted during the selective/custom build process (if using custom build). If you are a Facebook employee using PyTorch on mobile, please visit https://fburl.com/ptmfixes for possible resolutions. 'aten::_pin_memory' is only available for these backends: [MPS, BackendSelect, Python, FuncTorchDynamicLayerBackMode, Functionalize, Named, Conjugate, Negative, ZeroTensor, ADInplaceOrView, AutogradOther, AutogradCPU, AutogradCUDA, AutogradHIP, AutogradXLA, AutogradMPS, AutogradIPU, AutogradXPU, AutogradHPU, AutogradVE, AutogradLazy, AutogradMeta, AutogradPrivateUse1, AutogradPrivateUse2, AutogradPrivateUse3, AutogradNestedTensor, Tracer, AutocastCPU, AutocastCUDA, FuncTorchBatched, FuncTorchVmapMode, Batched, VmapMode, FuncTorchGradWrapper, PythonTLSSnapshot, FuncTorchDynamicLayerFrontMode, PythonDispatcher].
```